### PR TITLE
HDLC protocol may be doing things at carrier detection.

### DIFF
--- a/package/oem-e1.g2/mr17g-drv/mr17g_net.c
+++ b/package/oem-e1.g2/mr17g-drv/mr17g_net.c
@@ -701,6 +701,7 @@ void mr17g_net_link(struct net_device *ndev)
     if(  lstat > 0 || cfg->llpb ){
 	    if( !netif_carrier_ok(ndev) ){
             printk(KERN_NOTICE"%s: link UP\n",ndev->name);
+			hdlc_set_carrier(1,ndev);
        		netif_carrier_on(ndev);
 		    if( ch->chip->type != MR17G_MUXONLY ){
 		    	// Setup HDLC controller
@@ -712,6 +713,7 @@ void mr17g_net_link(struct net_device *ndev)
     }else if(  lstat==0 ){
 	    if( netif_carrier_ok(ndev) ){
             printk(KERN_NOTICE"%s: link DOWN\n",ndev->name);
+			hdlc_set_carrier(0,ndev);
 			netif_carrier_off(ndev);
 		    if( ch->chip->type != MR17G_MUXONLY ){
 		    	// Setup HDLC controller


### PR DESCRIPTION
hdlc_set_carrier() has to be used in addition to netif_carrier_on().